### PR TITLE
add gathering rel in the link, so a nofollow can be implemented

### DIFF
--- a/src/CamelSpider/Entity/Link.php
+++ b/src/CamelSpider/Entity/Link.php
@@ -14,6 +14,7 @@ class Link extends ArrayCollection implements InterfaceLink
         if (!is_null($node) && $node instanceof \DOMElement) {
             $link = array(
                 'href' => $node->getAttribute('href'),
+                'rel'  => $node->getAttribute('rel'),
             );
         } elseif (is_string($node)) {
             $link['href'] = $node;
@@ -41,10 +42,16 @@ class Link extends ArrayCollection implements InterfaceLink
         return $this->get('href');
     }
 
+    public function getRel()
+    {
+        return $this->get('rel');
+    }
+
     public function isWaiting()
     {
         return  ($this->get('status') === 0) ? true : false;
     }
+
     public function isDone()
     {
         return  ($this->get('status') === 1) ? true : false;
@@ -85,10 +92,8 @@ class Link extends ArrayCollection implements InterfaceLink
         return $this;
     }
 
-
     public function toArray()
     {
         return $this->toMinimal()->toArray();
     }
-
 }


### PR DESCRIPTION
I'm also looking at adding in Indexer::addLink() a test for nofollow. It could be hard coded, but I've thought about adding a LinkFilter class that basically would basically make sure the Link passed the test in the filter. For example, the SpiderAsserts::isDocumentLink would be put in a filter. The nofollow would go in a filter, custom rules for eliminating a link could go into a filter.

Here is how it would look https://gist.github.com/2880690

Let me know if you would like me to build that out.
